### PR TITLE
Fixed incorrect URL path in documentation 

### DIFF
--- a/ru/04_Компоненты/DocLister/10_Особенности.md
+++ b/ru/04_Компоненты/DocLister/10_Особенности.md
@@ -34,7 +34,7 @@
 </ul>
 <h3 class="sub-header">Компоненты на базе DocLister:</h3>
 <ul>
-	<li><a href="simplegallery/" title="SimpleGallery" target="_blank" class="text-bold">SimpleGallery</a> – вывод галереи на странице</li>
+	<li><a href="docs/tree/master/ru/04_Компоненты/SimpleGallery" title="SimpleGallery" target="_blank" class="text-bold">SimpleGallery</a> – вывод галереи на странице</li>
 	<li><a href="simpletube/" title="SimpleTube" target="_blank" class="text-bold">SimpleTube</a> – плагин и сниппет для создания видеогалерей
 </li>
 	<li><a href="simplefiles/" title="SimpleFiles" target="_blank" class="text-bold">SimpleFiles</a> – прикрепляем к странице файлы</li>

--- a/ru/04_Компоненты/DocLister/10_Особенности.md
+++ b/ru/04_Компоненты/DocLister/10_Особенности.md
@@ -20,13 +20,13 @@
 <h3 class="sub-header">На базе класса DocLister сформировано 12 сниппетов:</h3>
 <ul>
 	<li><strong>DocLister</strong> - основной сниппет для вывода информации по принципу сниппетов Ditto и CatalogView</li>
-	<li><a href="sistemnye-parametry/" title="DLcrumbs" target="_blank" class="text-bold">DLcrumbs</a> - для формирования хлебных крошек по принципу сниппета Breadcrumbs</li>
+	<li><a href="/ru/04_Компоненты/DLCrumbs" title="DLcrumbs" target="_blank" class="text-bold">DLcrumbs</a> - для формирования хлебных крошек по принципу сниппета Breadcrumbs</li>
 	<li><strong>DLglossary</strong> - для фильтрации документов по первому символу в определенном поле</li>
 	<li><strong>DLvaluelist</strong> - для замены сниппета DropDownDocs</li>
 	<li><strong>DLTemplate</strong> - для замены $modx-&gt;parseChunk()</li>
 	<li><strong>DLFirstChar</strong> - выборка документов и группировках в блоках по первой букве</li>
 	<li><strong>DLPrevNext</strong> - цикличная навигация вперед/назад между соседними документами</li>
-	<li><a href="dlmenu/" title="DLMenu" target="_blank" class="text-bold">DLMenu</a> - Построение меню неограниченой вложенности</li>
+	<li><a href="/ru/04_Компоненты/DLMenu" title="DLMenu" target="_blank" class="text-bold">DLMenu</a> - Построение меню неограниченой вложенности</li>
 	<li><strong>DLSitemap</strong> - Построение xml-карты сайта</li>
 	<li><strong>DLReflect</strong> - Построение списка дат</li>
 	<li><strong>DLReflectFilter</strong> - Фильтрация документов по датам</li>

--- a/ru/04_Компоненты/DocLister/10_Особенности.md
+++ b/ru/04_Компоненты/DocLister/10_Особенности.md
@@ -34,7 +34,7 @@
 </ul>
 <h3 class="sub-header">Компоненты на базе DocLister:</h3>
 <ul>
-	<li><a href="docs/tree/master/ru/04_Компоненты/SimpleGallery" title="SimpleGallery" target="_blank" class="text-bold">SimpleGallery</a> – вывод галереи на странице</li>
+	<li><a href="/ru/04_Компоненты/SimpleGallery" title="SimpleGallery" target="_blank" class="text-bold">SimpleGallery</a> – вывод галереи на странице</li>
 	<li><a href="simpletube/" title="SimpleTube" target="_blank" class="text-bold">SimpleTube</a> – плагин и сниппет для создания видеогалерей
 </li>
 	<li><a href="simplefiles/" title="SimpleFiles" target="_blank" class="text-bold">SimpleFiles</a> – прикрепляем к странице файлы</li>

--- a/ru/04_Компоненты/DocLister/10_Особенности.md
+++ b/ru/04_Компоненты/DocLister/10_Особенности.md
@@ -35,16 +35,16 @@
 <h3 class="sub-header">Компоненты на базе DocLister:</h3>
 <ul>
 	<li><a href="/ru/04_Компоненты/SimpleGallery" title="SimpleGallery" target="_blank" class="text-bold">SimpleGallery</a> – вывод галереи на странице</li>
-	<li><a href="simpletube/" title="SimpleTube" target="_blank" class="text-bold">SimpleTube</a> – плагин и сниппет для создания видеогалерей
+	<li><a href="/ru/04_Компоненты/SimpleTube" title="SimpleTube" target="_blank" class="text-bold">SimpleTube</a> – плагин и сниппет для создания видеогалерей
 </li>
-	<li><a href="simplefiles/" title="SimpleFiles" target="_blank" class="text-bold">SimpleFiles</a> – прикрепляем к странице файлы</li>
+	<li><a href="/ru/04_Компоненты/SimpleFile" title="SimpleFiles" target="_blank" class="text-bold">SimpleFiles</a> – прикрепляем к странице файлы</li>
 	<li>SimplePolls</li>
-	<li><a href="likedislike/" title="LikeDislike" target="_blank" class="text-bold">LikeDislike</a> – возможность ставить оценки</li>
-	<li><a href="formlister/" title="FormLister" target="_blank" class="text-bold">FormLister</a> - cниппет для работы с формами</li>
+	<li><a href="/ru/04_Компоненты/LikeDislike" title="LikeDislike" target="_blank" class="text-bold">LikeDislike</a> – возможность ставить оценки</li>
+	<li><a href="/ru/04_Компоненты/FormLister" title="FormLister" target="_blank" class="text-bold">FormLister</a> - cниппет для работы с формами</li>
 	<li>FastImageTV</li>
-	<li><a href="dlrequest/" title="DLRequest" target="_blank" class="text-bold">DLRequest</a> - запуск сниппетов с параметрами из get/post</li>
+	<li><a href="/ru/04_Компоненты/DLRequest" title="DLRequest" target="_blank" class="text-bold">DLRequest</a> - запуск сниппетов с параметрами из get/post</li>
 	<li>evoSearch</li>
 	<li>eFilter</li>
-	<li><a href="selector/" title="Selector" target="_blank" class="text-bold">Selector</a> - custom TV для составления списка документов</li>
+	<li><a href="/ru/04_Компоненты/Selector" title="Selector" target="_blank" class="text-bold">Selector</a> - custom TV для составления списка документов</li>
 </ul>
 <p>Автор: <i class="fa fa-github fa-lg text-primary"></i> <a href="https://github.com/AgelxNash" rel="nofollow" target="_blank">Agel_Nash</a></p>


### PR DESCRIPTION
Here https://docs.evo.im/04_extras/doclister/10_features.html is incorrect URL path for the internal files. 
